### PR TITLE
Rabbit: Fix terminal after running 'rabbit.py'

### DIFF
--- a/kano_init/ascii_art/rabbit.py
+++ b/kano_init/ascii_art/rabbit.py
@@ -238,7 +238,6 @@ def rabbit(cycles=1, start_direction='left-to-right'):
 
 
 if __name__ == "__main__":
-    init_curses()
     max_cycles = 3
     if len(sys.argv) > 1:
         max_cycles = int(sys.argv[1])
@@ -247,4 +246,4 @@ if __name__ == "__main__":
     if len(sys.argv) > 2 and sys.argv[2] == "right-to-left":
         start_direction = "right-to-left"
 
-    sys.exit(main(max_cycles, start_direction))
+    sys.exit(rabbit(max_cycles, start_direction))


### PR DESCRIPTION
KanoComputing/peldins#1872
When running the `rabbit.py` script directly, it used the `main` method
rather than the `rabbit` wrapper which handles constructing and
destructing the ncurses environment. If the environment isn't destructed
correctly, the terminal environment will be sullied. Fix this by using
the wrapper function rather than the `main` function directly.

cc @pazdera 
