### PR TITLE
Fix to allow root to login into the kit if kano-init in progress

### DIFF
--- a/autostart-kano-init.sh
+++ b/autostart-kano-init.sh
@@ -6,6 +6,14 @@
 # License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
 #
 
+# If we are not on tty1, exit immediately,
+# otherwise root would be "kano-inited" and unable to get a shell
+# while kano-init is in username-stage.
+#
+if [ `tty` != "/dev/tty1" ]; then
+	exit 0
+fi
+
 STATUS_FILE="/var/cache/kano-init/status.json"
 
 if [ `id -u` -eq 0 -a "`json-get $STATUS_FILE stage`" != "disabled" ]; then


### PR DESCRIPTION
@pazdera Radek, This change should fix this issue on KanoOS wheezy. On Jessie it is fixed differently as we integrate with systemd.
