### PR TITLE
Run kano overworld as the user so state is saved correctly.

### DIFF
--- a/kano_init/tasks/flow.py
+++ b/kano_init/tasks/flow.py
@@ -170,7 +170,9 @@ def do_love_stage(flow_params):
 
     if not flow_params.get('skip', False):
         clear_screen()
-        cmd = "/usr/bin/love /usr/bin/kanoOverworld.love --load=terminalForest"
+        # kanoOverworld needs to run as the user
+        # to access the savefile correctly.
+        cmd = 'su {} -c "/usr/bin/love /usr/bin/kanoOverworld.love --load" >>/var/log/kanoOverworld.log 2>&1'.format(init_status.username)
 
         os.system(cmd)
 


### PR DESCRIPTION
This should fix https://github.com/KanoComputing/kano-overworld/issues/96
@radujipa 
I also redirect the output of kanoOverworld to a file, as it is quite noisy. But I think we are still getting the result of keypresses on the screen.
