### PR TITLE
Adapt overscan settings during kano-init

### DIFF
--- a/kano_init/ascii_art/matrix.py
+++ b/kano_init/ascii_art/matrix.py
@@ -174,7 +174,11 @@ def debug(msg):
         f.write(str(msg) + '\n')
 
 
-def main(duration, show_face):
+def main(duration, show_face, callback):
+    # 'callback' is called if show_face==True
+    # just before it is displayed. This is to allow us to change
+    # overscan settings at this point.
+
     h, w = screen.getmaxyx()
 
     drops = []
@@ -184,6 +188,7 @@ def main(duration, show_face):
 
     tick = 0.025
     elapsed = 0
+    callback_called = False
     while True:
         elapsed += tick
         if elapsed < duration:
@@ -218,6 +223,10 @@ def main(duration, show_face):
             i += 1
 
         if show_face and elapsed > duration:
+            if callback and not callback_called:
+                callback()
+                callback_called = True
+
             face.draw_next()
 
         screen.refresh()
@@ -280,12 +289,12 @@ def shutdown_curses():
     curses.endwin()
 
 
-def matrix(duration=10, show_face=False):
+def matrix(duration=10, show_face=False, callback=None):
     status = 1
 
     try:
         init_curses()
-        status = main(duration, show_face)
+        status = main(duration, show_face, callback)
     finally:
         shutdown_curses()
 

--- a/kano_init/tasks/flow.py
+++ b/kano_init/tasks/flow.py
@@ -21,7 +21,7 @@ from kano.utils import run_cmd, ensure_dir, delete_dir
 
 from kano_init.paths import SUBSHELLRC_PATH
 from kano_init.terminal import typewriter_echo, clear_screen, user_input, \
-    write_flush, LEFT_PADDING
+    write_flush, LEFT_PADDING, set_overscan, reset_overscan
 from kano_init.status import Status
 from kano_init.ascii_art.matrix import matrix
 from kano_init.ascii_art.matrix_binary import matrix_binary
@@ -46,7 +46,8 @@ def do_username_stage(flow_params):
         username = make_username_unique(username)
     else:
         try:
-            matrix(2, True)
+            reset_overscan()
+            matrix(2, True, set_overscan)
         except:
             pass
         clear_screen()
@@ -184,7 +185,9 @@ def do_white_rabbit_stage(flow_params):
         os.system(cmd)
         delete_dir(rabbithole)
 
+        reset_overscan()
         matrix_binary(1, False)
+        set_overscan()
 
         clear_screen()
 
@@ -201,7 +204,9 @@ def do_love_stage(flow_params):
         # to access the savefile correctly.
         cmd = 'su {} -c "/usr/bin/love /usr/bin/kanoOverworld.love --load" >>/var/log/kanoOverworld.log 2>&1'.format(init_status.username)
 
+        reset_overscan()
         os.system(cmd)
+        set_overscan()
 
     init_status.stage = Status.FINAL_STAGE
     init_status.save()

--- a/kano_init/terminal.py
+++ b/kano_init/terminal.py
@@ -39,11 +39,18 @@ def set_overscan():
         pass
 
 
+def reset_overscan():
+    try:
+        subprocess.check_call(['overscan', '0', '0', '0', '0'])
+    except:
+        pass
+
+
 def restore_original_state():
     if sys.stdin.isatty() and original_state:
         fd = sys.stdin.fileno()
         termios.tcsetattr(fd, termios.TCSADRAIN, original_state)
-        subprocess.check_call(['overscan', '0', '0', '0', '0'])
+        reset_overscan()
 
 
 def save_original_state():


### PR DESCRIPTION
This PR switches overscan off for 'matrix' and 'overworld' steps in the the onboarding.
It is switched on again for the 'face' so that this is not cropped.
@alex5imon @tombettany 
