### PR TITLE
Remove obsolete call

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-init (3.2.0-1) unstable; urgency=low
+
+  * Remove use of kano_settings.system.advanced.set_user_cookies
+
+ -- Team Kano <dev@kano.me>  Tue, 13 Oct 2015 17:22:00 +0100
+
 kano-init (2.2.0-1) unstable; urgency=low
 
   * New versioning convention

--- a/kano_init/user.py
+++ b/kano_init/user.py
@@ -17,9 +17,6 @@ import shutil
 from kano.utils import run_cmd_log, run_cmd
 from kano.logging import logger
 
-from kano_settings.system.advanced import set_user_cookies
-
-
 DEFAULT_USER_PASSWORD = "kano"
 DEFAULT_USER_GROUPS = "tty,adm,dialout,cdrom,audio,users,sudo,video,games," + \
                       "plugdev,input,kanousers,i2c,gpio,spi"
@@ -140,9 +137,6 @@ def create_user(username):
     # Add the new user to all necessary groups
     cmd = "usermod -G '{}' {}".format(DEFAULT_USER_GROUPS, username)
     _, _, rv = run_cmd_log(cmd)
-
-    # Apply parental control configuration
-    set_user_cookies(enabled=None, username=username)
 
 
 def get_next_uid():


### PR DESCRIPTION
This PR removes use of kano_settings.system.advanced.set_user_cookies. It also bumps the version to allow 'Breaks' clause in kano-settings.
@tombettany 
