### PR TITLE
Removing kano-motd dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>=9.0.0), python
 
 Package: kano-init
 Architecture: all
-Depends: ${misc:Depends}, kano-motd, kano-toolset (>= 2.1-3),
+Depends: ${misc:Depends}, kano-toolset (>= 2.1-3),
          kano-settings (>=2.2-4), python
 Description: Initialize Kanux installation on a Kano kit
  This script asks for the user name, expands the root partition, and more.


### PR DESCRIPTION
- Should avoid installation, and therefore improve bootup speed

I don't think we've used it for a long time, what do you think @Ealdwulf @alex5imon @pazdera ?
