### PR TITLE
lock status file.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>=9.0.0), python
 
 Package: kano-init
 Architecture: all
-Depends: ${misc:Depends}, kano-toolset (>= 2.1-3),
+Depends: ${misc:Depends}, kano-toolset (>= 2.3.0-4),
          kano-settings (>=2.2-4), python
 Description: Initialize Kanux installation on a Kano kit
  This script asks for the user name, expands the root partition, and more.

--- a/kano_init/status.py
+++ b/kano_init/status.py
@@ -9,6 +9,7 @@ import os
 import json
 
 from kano.utils import ensure_dir
+from kano.utils.file_operations import open_locked
 from kano.logging import logger
 
 from kano_init.paths import STATUS_FILE_PATH
@@ -79,7 +80,7 @@ class Status(object):
             self.load()
 
     def load(self):
-        with open(self._status_file, 'r') as status_file:
+        with open_locked(self._status_file, 'r', timeout=1.0) as status_file:
             try:
                 data = json.load(status_file)
                 self._stage = data['stage']
@@ -96,7 +97,7 @@ class Status(object):
             'username': self._username
         }
 
-        with open(self._status_file, 'w') as status_file:
+        with open_locked(self._status_file, 'w', timeout=1.0) as status_file:
             json.dump(data, status_file)
             status_file.flush()
             os.fsync(status_file.fileno())


### PR DESCRIPTION
A pi in a workshop had corruption in its kano-init status file.
Not sure why this was but if tehre is a race condition, then it would be better for this file to be accessed under a lock.
@tombettany @skarbat 
Not necessary to merge for 3.3
