### PR TITLE
Fix for skip-mode

### DIFF
--- a/kano_init/tasks/flow.py
+++ b/kano_init/tasks/flow.py
@@ -180,6 +180,9 @@ def do_letters_stage(flow_params):
                     typewriter_echo(msg, trailing_linebreaks=2)
                     raw_input("Press [ENTER] to keep exploring.")
                     break
+    else:
+        # skip init flow, proceed to next stage
+        init_status.stage = Status.WHITE_RABBIT_STAGE
 
     init_status.save()
 


### PR DESCRIPTION
- I mistakenly broke skip mode in kano-init:
  https://github.com/KanoComputing/kano-init/commit/142ae009340730340fd6948cab1441c48e8b20b5#diff-7261bfa757330cd5bbb7a2608193b6eaL155
- kano-init would enter in an endless loop running the same stage
- Fixing by going forward to next stage in this case

@Ealdwulf @tombettany could you please have a look?
