### PR TITLE
Fixed literal to not wrap to the next line

### DIFF
--- a/po/es_AR.po
+++ b/po/es_AR.po
@@ -176,7 +176,7 @@ msgstr "¡A éste le sobran {number} caracteres! Intenta de nuevo. "
 msgid ""
 "Switches speak in code, 1s and 0s. 1 means yes. 0 means no. This is binary."
 msgstr ""
-"Estos interruptores hablan en ceros y unos, o en lo que se denomina \"código "
+"Estos interruptores hablan en ceros y unos, esto se denomina \"código "
 "binario\""
 
 #: ../kano_init/ascii_art/binary.py:37


### PR DESCRIPTION
Should fix this very subtle annoyance:

@tombettany @radujipa 

![unos-y-ceros](https://cloud.githubusercontent.com/assets/499442/18745247/74002436-80b9-11e6-8cca-f82a83d4f299.png)
