### PR TITLE
Rectify Spanish error message when username has invalid characters

### DIFF
--- a/po/es_AR.po
+++ b/po/es_AR.po
@@ -161,7 +161,7 @@ msgstr "Escribe un buen nombre."
 
 #: ../kano_init/tasks/flow.py:274
 msgid "Just one word, letters or numbers! Try again."
-msgstr "¡Sólo una palabra! Puedes usar letras o números. Intenta de nuevo"
+msgstr "¡Una palabra solamente! Puedes usar letras con números, sin acentos. Intenta de nuevo"
 
 #: ../kano_init/tasks/flow.py:277
 msgid "This one is already taken! Try again."


### PR DESCRIPTION
@tombettany I think the message is much clearer to the user now.
