### PR TITLE
Get touch flipping to work.

### DIFF
--- a/bin/overture-wrapper
+++ b/bin/overture-wrapper
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Copyright (C) 2018 Kano Computing Ltd.
+# License: http://www.gnu.org/licenses/gpl-2.0.txt GNU GPL v2
+#
+# overture-wrapper
+
+source /usr/share/kano-peripherals/scripts/flip_qt.sh
+
+/usr/bin/overture $*
+

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kano-init (4.0.0-0) unstable; urgency=low
+
+  * Add support for touch flipping for overture
+
+ -- Team Kano <dev@kano.me>  Mon, 4 Jun 2018 18:48:00 +0100
+
 kano-init (3.15.0-0) unstable; urgency=low
 
   * Added script to stop bootup on unsupported RPi boards

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper (>=9.0.0), python
 Package: kano-init
 Architecture: all
 Depends: ${misc:Depends}, kano-toolset (>= 2.3.0-4),
-         kano-settings (>=2.2-4), python, overture
+         kano-settings (>=2.2-4), python, overture, kano-touch-support
 Description: Initialize Kanux installation on a Kano kit
  This script asks for the user name, expands the root partition, and more.
 

--- a/kano_init/utils.py
+++ b/kano_init/utils.py
@@ -114,6 +114,7 @@ def start_lightdm():
     Starts the X server immediately, it is safe to call while overture is running
     '''
     run_cmd('systemctl start lightdm')
+    run_cmd('systemctl start kano-touch-flip.service')
 
 
 def start_dashboard_services(username):

--- a/systemd/system/overture.service
+++ b/systemd/system/overture.service
@@ -23,7 +23,7 @@ Wants=kano-settings.service
 After=kano-settings.service
 
 [Service]
-ExecStart=/usr/bin/overture
+ExecStart=/usr/bin/overture-wrapper
 Restart=no
 RemainAfterExit=yes
 


### PR DESCRIPTION
This PR wraps overture to start QT with flipping enabled.
It also starts the flip service for user programs.
Depends on https://github.com/KanoComputing/kano-peripherals/pull/65
