### PR TITLE
Remove redundant service start.

### DIFF
--- a/kano_init/utils.py
+++ b/kano_init/utils.py
@@ -114,7 +114,6 @@ def start_lightdm():
     Starts the X server immediately, it is safe to call while overture is running
     '''
     run_cmd('systemctl start lightdm')
-    run_cmd('systemctl start kano-touch-flip.service')
 
 
 def start_dashboard_services(username):


### PR DESCRIPTION
This PR removes starting of flip service, which actually happens anyway via kano-ui-autostart,
just like a normal boot.